### PR TITLE
Toggle the theme on pressing the enter key

### DIFF
--- a/src/Header.messages.jsx
+++ b/src/Header.messages.jsx
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'Schools & Partners',
     description: 'Link to the schools and partners landing page',
   },
+  'header.user.theme': {
+    id: 'header.user.theme',
+    defaultMessage: 'Toggle Theme',
+    description: 'Toggle between light and dark theme',
+  },
   'header.user.menu.dashboard': {
     id: 'header.user.menu.dashboard',
     defaultMessage: 'Dashboard',

--- a/src/ThemeToggleButton.jsx
+++ b/src/ThemeToggleButton.jsx
@@ -75,6 +75,12 @@ const ThemeToggleButton = () => {
     }
   };
 
+  const hanldeKeyUp = (event) => {
+    if (event.key === 'Enter') {
+      onToggleTheme();
+    }
+  }
+
   if (!isThemeToggleEnabled) {
     return <div />;
   }
@@ -84,7 +90,7 @@ const ThemeToggleButton = () => {
       <div className="light-theme-icon"><Icon src={WbSunny} /></div>
       <div className="toggle-switch">
         <label htmlFor="theme-toggle-checkbox" className="switch">
-          <input id="theme-toggle-checkbox" defaultChecked={cookies.get(themeCookie) === 'dark'} onChange={onToggleTheme} type="checkbox" />
+          <input id="theme-toggle-checkbox" defaultChecked={cookies.get(themeCookie) === 'dark'} onChange={onToggleTheme} onKeyUp={hanldeKeyUp} type="checkbox" />
           <span className="slider round" />
         </label>
       </div>

--- a/src/ThemeToggleButton.jsx
+++ b/src/ThemeToggleButton.jsx
@@ -3,11 +3,13 @@ import { getConfig } from '@edx/frontend-platform';
 import Cookies from 'universal-cookie';
 import { Icon } from '@openedx/paragon';
 import { WbSunny, Nightlight } from '@openedx/paragon/icons';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import messages from './Header.messages';
 
 const themeCookie = 'indigo-toggle-dark';
 const themeCookieExpiry = 90; // days
 
-const ThemeToggleButton = () => {
+const ThemeToggleButton = ({ intl }) => {
   const cookies = new Cookies();
   const isThemeToggleEnabled = getConfig().INDIGO_ENABLE_DARK_TOGGLE;
 
@@ -90,7 +92,7 @@ const ThemeToggleButton = () => {
       <div className="light-theme-icon"><Icon src={WbSunny} /></div>
       <div className="toggle-switch">
         <label htmlFor="theme-toggle-checkbox" className="switch">
-          <input id="theme-toggle-checkbox" defaultChecked={cookies.get(themeCookie) === 'dark'} onChange={onToggleTheme} onKeyUp={hanldeKeyUp} type="checkbox" />
+          <input id="theme-toggle-checkbox" defaultChecked={cookies.get(themeCookie) === 'dark'} onChange={onToggleTheme} onKeyUp={hanldeKeyUp} type="checkbox" title={intl.formatMessage(messages['header.user.theme'])} />
           <span className="slider round" />
         </label>
       </div>
@@ -99,4 +101,9 @@ const ThemeToggleButton = () => {
   );
 };
 
-export default ThemeToggleButton;
+ThemeToggleButton.propTypes = {
+  // i18n
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(ThemeToggleButton);

--- a/src/ThemeToggleButton.jsx
+++ b/src/ThemeToggleButton.jsx
@@ -79,7 +79,7 @@ const ThemeToggleButton = () => {
     if (event.key === 'Enter') {
       onToggleTheme();
     }
-  }
+  };
 
   if (!isThemeToggleEnabled) {
     return <div />;

--- a/src/ThemeToggleButton.test.jsx
+++ b/src/ThemeToggleButton.test.jsx
@@ -2,55 +2,51 @@
 import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, fireEvent } from '@testing-library/react';
-import ThemeToggleButton from './ThemeToggleButton';
 import { getConfig } from '@edx/frontend-platform';
-
+import ThemeToggleButton from './ThemeToggleButton';
 
 jest.mock('@edx/frontend-platform', () => ({
-    getConfig: jest.fn(),
+  getConfig: jest.fn(),
 }));
 
 const mockCookiesGet = jest.fn();
 const mockCookiesSet = jest.fn();
-jest.mock('universal-cookie', () => {
-    return jest.fn().mockImplementation(() => ({
-        get: mockCookiesGet, // Simulate initial light mode
-        set: mockCookiesSet,
-    }));
-});
+jest.mock('universal-cookie', () => jest.fn().mockImplementation(() => ({
+  get: mockCookiesGet, // Simulate initial light mode
+  set: mockCookiesSet,
+})));
 
 describe('ThemeToggleButton', () => {
-    beforeEach(() => {
-        
-        getConfig.mockReturnValue({
-            LMS_BASE_URL: 'https://fake.url',
-            INDIGO_ENABLE_DARK_TOGGLE: true,
-        });
-
-        // Reset body class
-        document.body.classList.remove('indigo-dark-theme');
+  beforeEach(() => {
+    getConfig.mockReturnValue({
+      LMS_BASE_URL: 'https://fake.url',
+      INDIGO_ENABLE_DARK_TOGGLE: true,
     });
 
-    it('calls onToggleTheme when Enter key is pressed', () => {
-        mockCookiesGet.mockReturnValue('light');
+    // Reset body class
+    document.body.classList.remove('indigo-dark-theme');
+  });
 
-        const { container } = render(
-            <IntlProvider locale="en" messages={{}}>
-                <ThemeToggleButton />
-            </IntlProvider>
-        );
-        const checkbox = container.querySelector('#theme-toggle-checkbox');
-        checkbox.focus();
-        fireEvent.keyUp(checkbox, { key: 'Enter' });
+  it('calls onToggleTheme when Enter key is pressed', () => {
+    mockCookiesGet.mockReturnValue('light');
 
-        expect(mockCookiesSet).toHaveBeenCalledWith(
-            'indigo-toggle-dark',
-            'dark',
-            expect.objectContaining({
-                domain: 'fake.url',
-                path: '/',
-                expires: expect.any(Date)
-            })
-        );
-    });
+    const { container } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <ThemeToggleButton />
+      </IntlProvider>,
+    );
+    const checkbox = container.querySelector('#theme-toggle-checkbox');
+    checkbox.focus();
+    fireEvent.keyUp(checkbox, { key: 'Enter' });
+
+    expect(mockCookiesSet).toHaveBeenCalledWith(
+      'indigo-toggle-dark',
+      'dark',
+      expect.objectContaining({
+        domain: 'fake.url',
+        path: '/',
+        expires: expect.any(Date),
+      }),
+    );
+  });
 });

--- a/src/ThemeToggleButton.test.jsx
+++ b/src/ThemeToggleButton.test.jsx
@@ -1,0 +1,56 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { render, fireEvent } from '@testing-library/react';
+import ThemeToggleButton from './ThemeToggleButton';
+import { getConfig } from '@edx/frontend-platform';
+
+
+jest.mock('@edx/frontend-platform', () => ({
+    getConfig: jest.fn(),
+}));
+
+const mockCookiesGet = jest.fn();
+const mockCookiesSet = jest.fn();
+jest.mock('universal-cookie', () => {
+    return jest.fn().mockImplementation(() => ({
+        get: mockCookiesGet, // Simulate initial light mode
+        set: mockCookiesSet,
+    }));
+});
+
+describe('ThemeToggleButton', () => {
+    beforeEach(() => {
+        
+        getConfig.mockReturnValue({
+            LMS_BASE_URL: 'https://fake.url',
+            INDIGO_ENABLE_DARK_TOGGLE: true,
+        });
+
+        // Reset body class
+        document.body.classList.remove('indigo-dark-theme');
+    });
+
+    it('calls onToggleTheme when Enter key is pressed', () => {
+        mockCookiesGet.mockReturnValue('light');
+
+        const { container } = render(
+            <IntlProvider locale="en" messages={{}}>
+                <ThemeToggleButton />
+            </IntlProvider>
+        );
+        const checkbox = container.querySelector('#theme-toggle-checkbox');
+        checkbox.focus();
+        fireEvent.keyUp(checkbox, { key: 'Enter' });
+
+        expect(mockCookiesSet).toHaveBeenCalledWith(
+            'indigo-toggle-dark',
+            'dark',
+            expect.objectContaining({
+                domain: 'fake.url',
+                path: '/',
+                expires: expect.any(Date)
+            })
+        );
+    });
+});


### PR DESCRIPTION
### Description

This pull request resolves several accessibility issues in the Tutor Indigo theme that were identified during a recent accessibility review. These updates aim to improve usability for all users, especially those relying on assistive technologies. The changes also help ensure compliance with recognized accessibility standards, such as the Web Content Accessibility Guidelines (WCAG) 2.1.

For further details, please refer to the related issue: [overhangio/tutor-indigo#146](https://github.com/overhangio/tutor-indigo/issues/146).

### Accessibility Fixes Implemented

---

#### Focus on the Theme Toggle Button

The theme toggle button lacked a visible focus indicator for keyboard users. This has been addressed by ensuring a clear focus style is applied.

- **Issue:** [Taiga - US/139](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/139)
- **Live Example:** [Home Page](https://sandbox.openedx.edly.io/)
- **Linked Pull Requests:** [Brand Openedx](https://github.com/edly-io/brand-openedx/pull/35) - [Tutor Indigo](https://github.com/overhangio/tutor-indigo/pull/147)

---

#### Theme Toggle Button Does Not Have an Accessible Name

The theme toggle button previously lacked an accessible name, which made it unclear to screen reader users. This update adds a title attribute with the value "Toggle Theme" to ensure assistive technologies can properly identify the button's purpose.

- **Issue:** [Taiga - US/95](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/95)
- **Live Example:** [Home Page](https://sandbox.openedx.edly.io/)

---


### Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report:  
[Accessibility Audit - Taiga US/111](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/111)

