### PR TITLE
Update sign out to logout for consistency

### DIFF
--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -35,7 +35,7 @@ const AuthenticatedUserDropdown = ({ intl, username }) => {
       href: getConfig().ORDER_HISTORY_URL,
     }] : []),
     {
-      message: intl.formatMessage(messages.signOut),
+      message: intl.formatMessage(messages.logout),
       href: getConfig().LOGOUT_URL,
     },
   ];

--- a/src/learning-header/messages.js
+++ b/src/learning-header/messages.js
@@ -41,10 +41,10 @@ const messages = defineMessages({
     defaultMessage: 'Skip to main content.',
     description: 'A link used by screen readers to allow users to skip to the main content of the page.',
   },
-  signOut: {
-    id: 'header.menu.signOut.label',
-    defaultMessage: 'Sign Out',
-    description: 'The label for the user menu Sign Out action.',
+  logout: {
+    id: 'header.menu.logout.label',
+    defaultMessage: 'Logout',
+    description: 'The label for the user menu Logout action.',
   },
 });
 


### PR DESCRIPTION
### 📄 Description
This PR resolves consistency of Inconsistent navigation across "Profile," "Account," and "Dashboard" pages.

## 🎯 Issue
Actual Result:
The "Profile," "Account," and "Dashboard" pages have different navigation lists, leading to inconsistency in the user experience. This inconsistency can confuse users and make navigation between pages less intuitive.
![image](https://github.com/user-attachments/assets/daf75029-fe48-489c-bbec-360ff882f494)


## ✅ Fix
Need to update the word from Sign Out to Logout for consistency among all the pages.

## 🔗 Related
Live Preview: [Demo Course – Progress](https://apps.sandbox.openedx.edly.io/courses/course-v1:edX+DemoX+Demo_Course/progress)
Taiga Ticket: [Inconsistent navigation across "Profile," "Account," and "Dashboard" pages](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/81)
Related GitHub Issue: https://github.com/overhangio/tutor-indigo/issues/146